### PR TITLE
add quotes around moustache expressions

### DIFF
--- a/.bluemix/catalog-api.pipeline.yml
+++ b/.bluemix/catalog-api.pipeline.yml
@@ -51,10 +51,10 @@ stages:
     value: undefined
     type: text
   - name: SAUCE_USERNAME
-    value: {{services.test.parameters.username}}
+    value: '{{services.test.parameters.username}}'
     type: text
   - name: SAUCE_ACCESS_KEY
-    value: {{services.test.parameters.key}}
+    value: '{{services.test.parameters.key}}'
     type: text
   - name: HOST
     value: ondemand.saucelabs.com

--- a/.bluemix/orders-api.pipeline.yml
+++ b/.bluemix/orders-api.pipeline.yml
@@ -26,10 +26,10 @@ stages:
     value: undefined
     type: text
   - name: SAUCE_USERNAME
-    value: {{services.test.parameters.username}}
+    value: '{{services.test.parameters.username}}'
     type: text
   - name: SAUCE_ACCESS_KEY
-    value: {{services.test.parameters.key}}
+    value: '{{services.test.parameters.key}}'
     type: text
   - name: HOST
     value: ondemand.saucelabs.com

--- a/.bluemix/ui.pipeline.yml
+++ b/.bluemix/ui.pipeline.yml
@@ -25,10 +25,10 @@ stages:
     value: undefined
     type: text
   - name: SAUCE_USERNAME
-    value: {{services.test.parameters.username}}
+    value: '{{services.test.parameters.username}}'
     type: text
   - name: SAUCE_ACCESS_KEY
-    value: {{services.test.parameters.key}}
+    value: '{{services.test.parameters.key}}'
     type: text
   - name: HOST
     value: ondemand.saucelabs.com


### PR DESCRIPTION
to avoid problem in Washington D.C, using branch public-eu-de,
was seeing {[object Object]=null}
in json instead of expected
moustache expression: {{services.test.parameters.username}}

occurred for urls:
https://cloud.ibm.com/devops/setup/deploy?repository=https%3A%2F%2Fgithub.com%2Fopen-toolchain%2Fmicroservices-helm-toolchain&branch=public-eu-de&env_id=ibm:yp:us-east

https://cloud.ibm.com/devops/setup/deploy?repository=https%3A%2F%2Fgithub.com%2Fopen-toolchain%2Fmicroservices-helm-toolchain&branch=public-eu-de&env_id=ibm:yp:jp-tok

but that microservice-helm-toolchain is not linked
from the "Create a Toolchain" list in those tok/wdc regions,
so only reproduced when customers manually enter those urls.